### PR TITLE
Update type hinting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 vendor
 composer.lock

--- a/src/class.dom-document.php
+++ b/src/class.dom-document.php
@@ -10,6 +10,8 @@ use PerryRylance\DOMDocument\DOMQueryResults;
 
 /**
  * This is the main class which builds on top of PHP's native DOMDocument
+ *
+ * @mixin DOMQueryResults
  */
 class DOMDocument extends \DOMDocument
 {


### PR DESCRIPTION
This pull request adds a PHPDoc @mixin tag to the DOMDocument class to allow for code completion in PHPStorm and other IDEs.
Sadly, the PhpDocumentor doesn't generate the appropriate Documentation for the @mixin tag.


I also added the PHPStorm Project file directory to the .gitignore file.