### PR TITLE
Fix handling for val() method on checkboxes and radio buttons #43

### DIFF
--- a/src/dom-document/class.dom-query-results.php
+++ b/src/dom-document/class.dom-query-results.php
@@ -882,6 +882,12 @@ class DOMQueryResults implements \ArrayAccess, \Countable, \Iterator
 			if(!$this->first())
 				return null;
 
+			// if the attribute doesn't exist, return null, as the implementation of the PHP \DOMElement
+            // class would return an empty string
+			if (!$this->first()->hasAttribute($arg)) {
+			    return null;
+            }
+
 			return $this->first()->getAttribute($arg);
 		}
 

--- a/src/dom-document/class.dom-query-results.php
+++ b/src/dom-document/class.dom-query-results.php
@@ -694,13 +694,18 @@ class DOMQueryResults implements \ArrayAccess, \Countable, \Iterator
 					{
 						case 'radio':
 						case 'checkbox':
-							// TODO: This is a poor design pattern really. This might create confusion if developers expect this method to return the value attribute, which is what I would expect.
-							return $el->hasAttribute('checked');
-							break;
+						    if ($el->hasAttribute('checked')) {
+						        if ($el->hasAttribute('value')) {
+						            return $el->getAttribute('value');
+                                }
+
+						        return true;
+                            }
+
+							return false;
 						
 						default:
 							return $el->getAttribute('value');
-							break;
 					}
 					break;
 					

--- a/src/dom-document/class.dom-query-results.php
+++ b/src/dom-document/class.dom-query-results.php
@@ -694,16 +694,11 @@ class DOMQueryResults implements \ArrayAccess, \Countable, \Iterator
 					{
 						case 'radio':
 						case 'checkbox':
-						    if ($el->hasAttribute('checked')) {
-						        if ($el->hasAttribute('value')) {
-						            return $el->getAttribute('value');
-                                }
-
-						        return true;
+                            if ($el->hasAttribute('value')) {
+                                return $el->getAttribute('value');
                             }
 
-							return false;
-						
+                            return 'on';
 						default:
 							return $el->getAttribute('value');
 					}


### PR DESCRIPTION
Should fix issue #43 

`val()` Method for checkbox/radio button will always return the value, wether the input is checked or not.
If the input node has no "value" attribute, the value will return "on".
This is the jQuery behavior.

The actual checked value should be retrieved with `$element->attr('checked')`.

Furthermore, i changed so that the `attr()` implementation on DOMQueryResult will now return null instead of an empty string if retrieving the value for a non-existing attribute.
(The PHP \DOMElement was returning an empty string if no attribute was found which i consider wrong for our usecase)

jQuery's `attr()` method returns `undefined` for non-existing attributes, so null should be fine.